### PR TITLE
Decouple css from js code

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,20 +1,21 @@
 let counter = 0;
 
 function blockSponsoredContent() {
-  const liElements = document.querySelectorAll("li");
+  const liElements = document.querySelectorAll(
+    "li:not(.flagged-sponsored-product)"
+  );
+
+  if (!liElements || liElements.length === 0) {
+    return;
+  }
+
   liElements.forEach((liElement) => {
     const labelElement = liElement.querySelector(".label-text");
     if (labelElement && labelElement.textContent === "Sponsored") {
       counter++;
 
-      liElement.style.border = "1px solid red";
-      liElement.style.boxShadow = "0px 0px 5px 0px red";
-
-      labelElement.style.border = "1px solid red";
-      labelElement.style.borderRadius = "5px";
-      labelElement.style.padding = "1px 4px";
-      labelElement.style.fontWeight = "bold";
-      labelElement.style.color = "red";
+      liElement.classList.add("flagged-sponsored-product");
+      labelElement.classList.add("flagged-sponsored-product-label");
     }
   });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
             "matches": [
                 "https://www.skroutz.gr/*"
             ],
+            "css": ["style.css"],
             "js": [
                 "background.js"
             ],

--- a/popup.html
+++ b/popup.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8" />
     <title>Skroutz Sponsored Flagger</title>
     <link rel="stylesheet" href="style.css" />
-    <script src="popup.js"></script>
   </head>
-  <body>
+  <body class="popup-body">
     <p>
       Sponsored content flagged: <span id="countDisplay">Loading count...</span>
     </p>
   </body>
+  <script src="popup.js"></script>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,18 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Skroutz Ad Blocker Popup</title>
-    <style>
-      body {
-        width: 200px;
-      }
-    </style>
- <head>
     <meta charset="utf-8" />
     <title>Skroutz Sponsored Flagger</title>
+    <link rel="stylesheet" href="style.css" />
     <script src="popup.js"></script>
   </head>
   <body>
-    <p>Sponsored content flagged: <span id="countDisplay">Loading count...</span></p>
+    <p>
+      Sponsored content flagged: <span id="countDisplay">Loading count...</span>
+    </p>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-body{
+.popup-body{
   width: 200px;
 }
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,16 @@
+body{
+  width: 200px;
+}
+
+.flagged-sponsored-product {
+  border: 1px solid red;
+  box-shadow: 0px 0px 5px 0px red;
+}
+
+.flagged-sponsored-product-label {
+  border: 1px solid red;
+  border-radius: 5px;
+  padding: 1px 4px;
+  font-weight: bold !important;
+  color: red !important;
+}


### PR DESCRIPTION
## Why

- Because you can :)
- Higher maintainability of styles
- During the retrieval of all `li` HTML elements, you could ignore those you have already marked as the 'bad boys'.
- A file with .css extension allows the code editor to help the dev in comparison with the injection of the CSS code in a script