### PR TITLE
Split webpack configuration for build based on the dest browser

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "git-blame.gitWebUrl": ""
+  "git-blame.gitWebUrl": "",
+  "window.title": "${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}${separator}[Branch: refactor/webpack-config]"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "git-blame.gitWebUrl": "",
-  "window.title": "${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}${separator}[Branch: refactor/webpack-config]"
+  "git-blame.gitWebUrl": ""
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "typescript": "^5.0.4",
         "webpack": "^5.81.0",
         "webpack-cli": "^5.0.2",
+        "webpack-merge": "^5.10.0",
         "zip-webpack-plugin": "^4.0.1"
       }
     },
@@ -970,6 +971,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/fs.realpath": {
@@ -2065,12 +2075,13 @@
       }
     },
     "node_modules/webpack-merge": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
         "wildcard": "^2.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "clean-webpack-plugin": "^4.0.0"
   },
   "scripts": {
-    "build:chrome": "webpack --config webpack/webpack.chrome.config.js",
-    "build:firefox": "webpack --config webpack/webpack.firefox.config.js"
+    "build:chrome": "webpack --env chrome",
+    "build:firefox": "webpack --env firefox"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^11.0.0",
@@ -13,6 +13,7 @@
     "typescript": "^5.0.4",
     "webpack": "^5.81.0",
     "webpack-cli": "^5.0.2",
+    "webpack-merge": "^5.10.0",
     "zip-webpack-plugin": "^4.0.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,11 @@
+const { merge } = require("webpack-merge");
+
+const commonConfig = require("./webpack/webpack.common.config");
+
+module.exports = (env) => {
+  const browser = env.chrome ? "chrome" : "firefox";
+
+  const config = require(`./webpack/webpack.${browser}.config`);
+
+  return merge(commonConfig, config);
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,10 +2,26 @@ const { merge } = require("webpack-merge");
 
 const commonConfig = require("./webpack/webpack.common.config");
 
-module.exports = (env) => {
-  const browser = env.chrome ? "chrome" : "firefox";
+const supportedBrowsersNames = ["chrome", "firefox"];
+const getBrowserName = (env) => {
+  const browserName = supportedBrowsersNames.find(
+    (supportedBrowserName) => env[supportedBrowserName] === true
+  );
 
-  const config = require(`./webpack/webpack.${browser}.config`);
+  return browserName;
+};
+
+module.exports = (env) => {
+  const browserName = getBrowserName(env);
+  if (!browserName) {
+    const supportedBrowsersList = supportedBrowsersNames.join(", ");
+
+    throw new Error(
+      `Parameter env should be one of the following values: ${supportedBrowsersList}`
+    );
+  }
+
+  const config = require(`./webpack/webpack.${browserName}.config`);
 
   return merge(commonConfig, config);
 };

--- a/webpack/webpack.chrome.config.js
+++ b/webpack/webpack.chrome.config.js
@@ -1,17 +1,12 @@
 const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ZipWebpackPlugin = require("zip-webpack-plugin");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = {
-  mode: "production",
-  entry: "./src/background.ts",
   output: {
-    filename: "background.js",
     path: path.resolve(__dirname, "../build/chrome_build"),
   },
   plugins: [
-    new CleanWebpackPlugin(),
     new CopyWebpackPlugin({
       patterns: [
         { from: "src/popup/popup.js", to: "popup.js" },
@@ -28,16 +23,4 @@ module.exports = {
       cleanStaleWebpackAssets: true,
     }),
   ],
-  resolve: {
-    extensions: [".ts", ".js"],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: "ts-loader",
-        exclude: /node_modules/,
-      },
-    ],
-  },
 };

--- a/webpack/webpack.common.config.js
+++ b/webpack/webpack.common.config.js
@@ -1,0 +1,22 @@
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+
+module.exports = {
+  mode: "production",
+  entry: "./src/background.ts",
+  output: {
+    filename: "background.js",
+  },
+  plugins: [new CleanWebpackPlugin()],
+  resolve: {
+    extensions: [".ts", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      },
+    ],
+  },
+};

--- a/webpack/webpack.firefox.config.js
+++ b/webpack/webpack.firefox.config.js
@@ -1,17 +1,12 @@
 const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ZipWebpackPlugin = require("zip-webpack-plugin");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = {
-  mode: "production",
-  entry: "./src/background.ts",
   output: {
-    filename: "background.js",
     path: path.resolve(__dirname, "../build/firefox_build"),
   },
   plugins: [
-    new CleanWebpackPlugin(),
     new CopyWebpackPlugin({
       patterns: [
         { from: "src/popup/popup.js", to: "popup.js" },
@@ -28,16 +23,4 @@ module.exports = {
       cleanStaleWebpackAssets: true,
     }),
   ],
-  resolve: {
-    extensions: [".ts", ".js"],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: "ts-loader",
-        exclude: /node_modules/,
-      },
-    ],
-  },
 };


### PR DESCRIPTION
Makes the maintenance of webpack's configuration a bit easier, until you decide to hug Vite :P

Specifying the variable `env` in the `npm scripts`, you could dynamically generate the whole webpack's configuration for the specified browser.